### PR TITLE
updated the condition of mdt mtu - JIRA 47

### DIFF
--- a/CISCO/IOS_XR/.meta_multicast_routing.xml
+++ b/CISCO/IOS_XR/.meta_multicast_routing.xml
@@ -7,7 +7,7 @@
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1655727596199</value>
+            <value>1656084282259</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1655727596012</value>
+            <value>1656084282214</value>
         </entry>
         <entry>
             <key>MODEL</key>

--- a/CISCO/IOS_XR/multicast_routing.xml
+++ b/CISCO/IOS_XR/multicast_routing.xml
@@ -54,6 +54,8 @@ multicast-routing
 {/if}
 {if isset($vrf.vrf_mdt_mtu)}
   mdt mtu {$vrf.vrf_mdt_mtu}
+{else}
+  mdt mtu 1524
 {/if}
   rate-per-route
   interface all enable
@@ -77,6 +79,8 @@ multicast-routing
   {/if}
   {if isset($af.vrf_mdt_mtu)}
    mdt mtu {$af.vrf_mdt_mtu}
+  {else}
+   mdt mtu 1524
   {/if}
   rate-per-route
   interface all enable


### PR DESCRIPTION
If there is not mdt mtu conf on source router, then we will apply the fixed configuration 'mdt mtu 1524' on destination router.