### PR TITLE
Change the default action on route-policy to drop, unless the last st…

### DIFF
--- a/CISCO/IOS_XR/.meta_route_policy.xml
+++ b/CISCO/IOS_XR/.meta_route_policy.xml
@@ -7,7 +7,7 @@
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1654633745593</value>
+            <value>1656556086640</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1654633745585</value>
+            <value>1656556086630</value>
         </entry>
         <entry>
             <key>MODEL</key>

--- a/CISCO/IOS_XR/route_policy.xml
+++ b/CISCO/IOS_XR/route_policy.xml
@@ -375,7 +375,7 @@ route-policy {$params.object_id}
   {if $statements@last}
   
 else 
-    {if $statements.action == "permit"}
+    {if $statements.action == "permit" && ($statements@total == 0 && $statements@last)}
   pass
     {else}
   drop

--- a/LINUX/CISCO_IOS_emulation/.meta_ip_vrf.xml
+++ b/LINUX/CISCO_IOS_emulation/.meta_ip_vrf.xml
@@ -7,7 +7,7 @@
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1655904126819</value>
+            <value>1656536680285</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1655904126799</value>
+            <value>1656536680270</value>
         </entry>
         <entry>
             <key>MODEL</key>


### PR DESCRIPTION
Change the default action on route-policy to drop, unless the last statement is permit and empty.

For example:

route-map BGP_LIGHT permit 10
 match ip address prefix-list ROTA_DEFAULT
!

Should be on XR:

route-policy BGP_LIGHT
  if  ((destination in pfx_ROTA_DEFAULT))  then
  pass
else
  drop
  endif
  !
end-policy

And

route-map BGP_LIGHT permit 10
 match ip address prefix-list ROTA_DEFAULT
!
route-map BGP_LIGHT permit 20
!

Should be translated to:

route-policy BGP_LIGHT
  if  ((destination in pfx_ROTA_DEFAULT))  then
  pass
else
  pass
  endif
  !
end-policy
