### PR TITLE
fix for the command 'conform-action transmit'

### DIFF
--- a/CISCO/IOS_XR/.meta_policy_map.xml
+++ b/CISCO/IOS_XR/.meta_policy_map.xml
@@ -7,7 +7,7 @@
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1656517782802</value>
+            <value>1660108798159</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1656517782784</value>
+            <value>1660108798070</value>
         </entry>
         <entry>
             <key>MODEL</key>

--- a/CISCO/IOS_XR/policy_map.xml
+++ b/CISCO/IOS_XR/policy_map.xml
@@ -303,11 +303,11 @@ policy-map  {$params.object_id}
   shape {$pmap_class.shape} {$pmap_class.shape_rate} bps{if isset($pmap_class.shape_excess_burst)} {$pmap_class.shape_excess_burst} bytes{/if}
   {/if} 
   {if isset($pmap_class.conform_action)}
-  conform-action {$pmap_class.conform_action|replace:'-':' '|replace:'transmit':''}
+  conform-action {$pmap_class.conform_action|replace:'set-dscp-transmit':'set dscp'}
   {/if} 
   {if isset($pmap_class.exceed_action)}
     {if (!isset($pmap_class.conform_action)) || (isset($pmap_class.conform_action) && $pmap_class.conform_action !== "drop")}
-  exceed-action {$pmap_class.exceed_action|replace:'-':' '|replace:'transmit':''}
+  exceed-action {$pmap_class.exceed_action|replace:'set-dscp-transmit':'set dscp'}
     {/if}
   {/if} 
   {*if isset($pmap_class.violate_action) && (isset($pmap_class.conform_action) && $pmap_class.conform_action != "drop") && (isset($pmap_class.exceed_action) && $pmap_class.exceed_action != "drop")}


### PR DESCRIPTION
Under police rate configuration, the knob transmit after conform-action was being replaced by blank space.

Instead:
policy-map CUSTOMER_100MB_VPN-IP
 class Voz_VPN-IP
  police rate percent 10 
   conform-action
   exceed-action drop

We should have:
policy-map CUSTOMER_100MB_VPN-IP
 class Voz_VPN-IP
  police rate percent 10 
   conform-action transmit
   exceed-action drop