### PR TITLE
Fixed class-map support for ipv6

### DIFF
--- a/CISCO/IOS_XR/.meta_class_map.xml
+++ b/CISCO/IOS_XR/.meta_class_map.xml
@@ -7,7 +7,7 @@
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1654633730486</value>
+            <value>1661886740317</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1654633730477</value>
+            <value>1661886740311</value>
         </entry>
         <entry>
             <key>MODEL</key>

--- a/CISCO/IOS_XR/class_map.xml
+++ b/CISCO/IOS_XR/class_map.xml
@@ -66,7 +66,21 @@
     </parser>
   </command>
   <command name="CREATE">
-    <operation><![CDATA[{if isset($params.matches)}
+    <operation><![CDATA[{capture}
+{assign var="match_acl_type" value=[]}
+{foreach $params.matches as $m}
+    {foreach $ip_access_list as $ip_acl}
+        {if $ip_acl.object_id == $m.match_access_group_value }
+            {if $ip_acl.type == 'ipv6'}
+                {$match_acl_type.{$m.match_access_group_value} = "ipv6"}
+            {else}
+                {$match_acl_type.{$m.match_access_group_value} = "ipv4"}
+            {/if}
+        {/if}
+    {/foreach}
+{/foreach}
+{/capture}
+{if isset($params.matches)}
 !
 class-map {$params.statement} {$params.object_id}
 {foreach $params.matches as $m}
@@ -75,7 +89,7 @@ class-map {$params.statement} {$params.object_id}
   {if isset($m.match_any)} {$m.match_any} 
   {else if isset($m.match_cmd_dscp)}{$m.match_cmd_dscp} 
   {else if isset($m.match_cmd_precedence)}{$m.match_cmd_precedence} 
-  {else if isset($m.match_cmd_access_group) && isset($m.match_access_group_value)}{$m.match_cmd_access_group} ipv4 {$m.match_access_group_value}
+  {else if isset($m.match_cmd_access_group) && isset($m.match_access_group_value)}{$m.match_cmd_access_group} {$match_acl_type.{$m.match_access_group_value}} {$m.match_access_group_value}
   {else if isset($m.match_cmd_mpls)}{$m.match_cmd_mpls} {/if} {if isset($m.match_value)}{$m.match_value}  
   {/if}
 {/strip}


### PR DESCRIPTION
The match statements in class-map, are hardcoded to put always the string "ipv4" doesnt care if access list is ipv6 or ipv4:

TST access list is ipv6:

Before Fix
class-map match-all FILTRO_ICMP_BGPLT
match  access-group ipv4 TST
end-class-map
root
!

After Fix
class-map match-all FILTRO_ICMP_BGPLT
match  access-group ipv6 TST
end-class-map
root
!
