### PR TITLE
Fix for the Key Chain XR MS

### DIFF
--- a/CISCO/IOS_XR/.meta_key_chain.xml
+++ b/CISCO/IOS_XR/.meta_key_chain.xml
@@ -7,7 +7,7 @@
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1654164907967</value>
+            <value>1661893033671</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1654164907958</value>
+            <value>1661893033666</value>
         </entry>
         <entry>
             <key>MODEL</key>

--- a/CISCO/IOS_XR/key_chain.xml
+++ b/CISCO/IOS_XR/key_chain.xml
@@ -43,7 +43,9 @@
 !
 key chain {$params.object_id}
  key {$params.key}
-   key-string 7 {$params.key_string}
+   accept-lifetime 00:00:00 january 01 1993 infinite
+   key-string password {$params.key_string}
+   send-lifetime 00:00:00 january 01 1993 infinite
 !
 root
 {/if}]]></operation>


### PR DESCRIPTION
Fix due to this error:

ERROR: Cannot run CREATE on microservice: key_chain, response=Command failed on the device: !
key-string 7 107A5A15561142055D277E6A267E03181125
@Invalid input detected@

Fixed the XR cli for the key chain:

key chain ISIS-PWD
 key 1
  accept-lifetime 00:00:00 january 01 1993 infinite
  key-string password 0232575758005F2F1D6D5D58074122263F32
  send-lifetime 00:00:00 january 01 1993 infinite
  cryptographic-algorithm HMAC-MD5
 !
!