### PR TITLE
Fixed match dscp

### DIFF
--- a/CISCO/IOS_XR/.meta_class_map.xml
+++ b/CISCO/IOS_XR/.meta_class_map.xml
@@ -7,7 +7,7 @@
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1661886740317</value>
+            <value>1661954695656</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1661886740311</value>
+            <value>1661954695649</value>
         </entry>
         <entry>
             <key>MODEL</key>

--- a/CISCO/IOS_XR/class_map.xml
+++ b/CISCO/IOS_XR/class_map.xml
@@ -83,16 +83,17 @@
 {if isset($params.matches)}
 !
 class-map {$params.statement} {$params.object_id}
+
 {foreach $params.matches as $m}
-{strip}
   match {if isset($m.not)} {$m.not} {/if}
+  {strip}
   {if isset($m.match_any)} {$m.match_any} 
   {else if isset($m.match_cmd_dscp)}{$m.match_cmd_dscp} 
   {else if isset($m.match_cmd_precedence)}{$m.match_cmd_precedence} 
   {else if isset($m.match_cmd_access_group) && isset($m.match_access_group_value)}{$m.match_cmd_access_group} {$match_acl_type.{$m.match_access_group_value}} {$m.match_access_group_value}
   {else if isset($m.match_cmd_mpls)}{$m.match_cmd_mpls} {/if} {if isset($m.match_value)}{$m.match_value}  
+  {/strip}
   {/if}
-{/strip}
 {/foreach}
 
 end-class-map


### PR DESCRIPTION
The match statements are all together, raising errors in IOS-XR configuration.

BEFORE FIX:

**class-map match-any   POLI_Ouro_VPN-IP
match    dscp af21 match  dscp cs3  af31 match    dscp af21
end-class-map
root**

When apply to XR
RP/0/RP0/CPU0:xrv9000-1(config)#class-map match-any   POLI_Ouro_VPN-IP
RP/0/RP0/CPU0:xrv9000-1(config-cmap)#match

Invalid number(-62) sent as ASCII value to command-line process from VTY/TTY, refreshing prompt.
RP/0/RP0/CPU0:xrv9000-1(config-cmap)#

Invalid number(-96) sent as ASCII value to command-line process from VTY/TTY, refreshing prompt.
RP/0/RP0/CPU0:xrv9000-1(config-cmap)#   dscp af21 match

Invalid number(-62) sent as ASCII value to command-line process from VTY/TTY, refreshing prompt.
RP/0/RP0/CPU0:xrv9000-1(config-cmap)#

Invalid number(-96) sent as ASCII value to command-line process from VTY/TTY, refreshing prompt.
RP/0/RP0/CPU0:xrv9000-1(config-cmap)# dscp cs3

Invalid number(-62) sent as ASCII value to command-line process from VTY/TTY, refreshing prompt.
RP/0/RP0/CPU0:xrv9000-1(config-cmap)#

Invalid number(-96) sent as ASCII value to command-line process from VTY/TTY, refreshing prompt.
RP/0/RP0/CPU0:xrv9000-1(config-cmap)# af31 match

Invalid number(-62) sent as ASCII value to command-line process from VTY/TTY, refreshing prompt.
RP/0/RP0/CPU0:xrv9000-1(config-cmap)#

Invalid number(-96) sent as ASCII value to command-line process from VTY/TTY, refreshing prompt.
RP/0/RP0/CPU0:xrv9000-1(config-cmap)# dscp af21
                                       ^
% Invalid input detected at '^' marker.
RP/0/RP0/CPU0:xrv9000-1(config-cmap)#end-class-map
RP/0/RP0/CPU0:xrv9000-1(config)#root

-----------------------------------------------------------------------------------------------------------------
AFTER FIX:

**class-map match-any POLI_Ouro_VPN-IP
  match  dscp af21
  match  dscp cs3  af31
  match  dscp af21
end-class-map
root**
!
When Apply to IOS-XR

RP/0/RP0/CPU0:xrv9000-1(config)#class-map match-any POLI_Ouro_VPN-IP
RP/0/RP0/CPU0:xrv9000-1(config-cmap)#  match  dscp af21
RP/0/RP0/CPU0:xrv9000-1(config-cmap)#  match  dscp cs3  af31
RP/0/RP0/CPU0:xrv9000-1(config-cmap)#  match  dscp af21
RP/0/RP0/CPU0:xrv9000-1(config-cmap)#end-class-map
RP/0/RP0/CPU0:xrv9000-1(config)#root
RP/0/RP0/CPU0:xrv9000-1(config)#!
RP/0/RP0/CPU0:xrv9000-1(config)#commit
Wed Aug 31 14:21:44.945 UTC
RP/0/RP0/CPU0:xrv9000-1(config)#
RP/0/RP0/CPU0:xrv9000-1#sh class-map
Wed Aug 31 14:23:16.498 UTC
class-map match-any POLI_Voz_VPN-IP
 match dscp ef cs5
 end-class-map
!
**class-map match-any POLI_Ouro_VPN-IP
 match dscp af21 cs3 af31
 end-class-map
!**
class-map match-any POLI_Video_VPN-IP
 match dscp af41 cs4
 end-class-map
!
RP/0/RP0/CPU0:xrv9000-1#


