### PR TITLE
Fix address family

### DIFF
--- a/CISCO/IOS_XR/.meta_address_family.xml
+++ b/CISCO/IOS_XR/.meta_address_family.xml
@@ -7,7 +7,7 @@
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1656676348430</value>
+            <value>1661987747306</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1656676348196</value>
+            <value>1661987747300</value>
         </entry>
         <entry>
             <key>MODEL</key>

--- a/CISCO/IOS_XR/.meta_class_map.xml
+++ b/CISCO/IOS_XR/.meta_class_map.xml
@@ -7,7 +7,7 @@
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1661886740317</value>
+            <value>1661954695656</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1661886740311</value>
+            <value>1661954695649</value>
         </entry>
         <entry>
             <key>MODEL</key>

--- a/CISCO/IOS_XR/address_family.xml
+++ b/CISCO/IOS_XR/address_family.xml
@@ -244,6 +244,15 @@
     <operation><![CDATA[{if isset ($params.router_bgp) && (isset($params.neighbors) && count($params.neighbors) > 0)}
 !
 router bgp {$params.router_bgp}
+{capture}
+{assign var="unique_neighbors" value=[]}
+{foreach $params.neighbors  as $neighbor}
+    {$unique_neighbors[$neighbor.bgp_neighbor] = {$params.bgp_address_family}} 
+{/foreach}
+{/capture}
+{foreach $unique_neighbors as $key => $value}
+ neighbor {$key} address-family {$value} unicast
+{/foreach}
 {foreach $params.neighbors  as $neighbor}
 {if isset($neighbor.bgp_ipv4_private_as)} neighbor {$neighbor.bgp_neighbor} address-family {$params.bgp_address_family} unicast {$neighbor.bgp_ipv4_private_as}
 {/if}

--- a/CISCO/IOS_XR/class_map.xml
+++ b/CISCO/IOS_XR/class_map.xml
@@ -83,16 +83,17 @@
 {if isset($params.matches)}
 !
 class-map {$params.statement} {$params.object_id}
+
 {foreach $params.matches as $m}
-{strip}
   match {if isset($m.not)} {$m.not} {/if}
+  {strip}
   {if isset($m.match_any)} {$m.match_any} 
   {else if isset($m.match_cmd_dscp)}{$m.match_cmd_dscp} 
   {else if isset($m.match_cmd_precedence)}{$m.match_cmd_precedence} 
   {else if isset($m.match_cmd_access_group) && isset($m.match_access_group_value)}{$m.match_cmd_access_group} {$match_acl_type.{$m.match_access_group_value}} {$m.match_access_group_value}
   {else if isset($m.match_cmd_mpls)}{$m.match_cmd_mpls} {/if} {if isset($m.match_value)}{$m.match_value}  
+  {/strip}
   {/if}
-{/strip}
 {/foreach}
 
 end-class-map


### PR DESCRIPTION
In IOS-XR Address Family Configuration was missing the command:

neighbor A.B.C.D address-family <ipv4|ipv6> unicast

BEFORE_FIX
---------------------------------------------------
!############# MS address_family #############
!
router bgp 10429
 neighbor 189.20.5.158 address-family ipv4 unicast default-originate
 neighbor 189.20.5.158 address-family ipv4 unicast remove-private-as
 neighbor 189.20.5.158 address-family ipv4 unicast soft-reconfiguration inbound
 neighbor 189.20.5.158 address-family ipv4 unicast route-policy RCV_FROM_189.20.5.158_BGP_LIGHT in
 neighbor 189.20.5.158 address-family ipv4 unicast route-policy BGP_LIGHT out
 neighbor 189.20.5.158 address-family ipv4 unicast maximum-prefix  250 80
!
root

AFTER_FIX
--------------------------------------------------------
!############# MS address_family #############
!
router bgp 10429
 **neighbor 189.20.5.158 address-family ipv4 unicast**
 neighbor 189.20.5.158 address-family ipv4 unicast default-originate
 neighbor 189.20.5.158 address-family ipv4 unicast remove-private-as
 neighbor 189.20.5.158 address-family ipv4 unicast soft-reconfiguration inbound
 neighbor 189.20.5.158 address-family ipv4 unicast route-policy RCV_FROM_189.20.5.158_BGP_LIGHT in
 neighbor 189.20.5.158 address-family ipv4 unicast route-policy BGP_LIGHT out
 neighbor 189.20.5.158 address-family ipv4 unicast maximum-prefix  250 80
!
root