### PR TITLE
Fix for the ISIS circuit-type on IOS-XR MS

### DIFF
--- a/CISCO/IOS_XR/.meta_router_isis.xml
+++ b/CISCO/IOS_XR/.meta_router_isis.xml
@@ -7,7 +7,7 @@
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1654770628127</value>
+            <value>1662494048039</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1654770628121</value>
+            <value>1662494048020</value>
         </entry>
         <entry>
             <key>MODEL</key>

--- a/CISCO/IOS_XR/router_isis.xml
+++ b/CISCO/IOS_XR/router_isis.xml
@@ -144,7 +144,7 @@ router {$params.object_id} 1
 
 {foreach $params.interfaces as $itf}
  interface {$itf.interface}
- {if isset($itf.isis_circuit_level)} circuit-type {$params.isis_circuit_level}
+ {if isset($itf.isis_circuit_level)} circuit-type {$itf.isis_circuit_level}
  {/if}
   {if isset($itf.isis_auth_key)}  hello-padding disable
    hello-password keychain  {$itf.isis_auth_key}


### PR DESCRIPTION
Before the fix:

router isis vivo 1
 interface GigabitEthernet0/2/0/6
  circuit-type
  hello-padding disable
  hello-password keychain  ISIS-PWD
  point-to-point
  csnp-interval  10 level-2}
  root
!

After the fix:

router isis vivo 1
 interface GigabitEthernet0/2/0/6
  circuit-type level-2-only
  hello-padding disable
  hello-password keychain  ISIS-PWD
  point-to-point
  csnp-interval  10 level-2}
  root
!