### PR TITLE
Fix for the ISIS csnp-level command on IOS-XR MS

### DIFF
--- a/CISCO/IOS_XR/.meta_router_isis.xml
+++ b/CISCO/IOS_XR/.meta_router_isis.xml
@@ -7,7 +7,7 @@
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1662681384058</value>
+            <value>1662782265308</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1662681384053</value>
+            <value>1662782265303</value>
         </entry>
         <entry>
             <key>MODEL</key>

--- a/CISCO/IOS_XR/router_isis.xml
+++ b/CISCO/IOS_XR/router_isis.xml
@@ -147,11 +147,11 @@ router {$params.object_id} 0
  {if isset($itf.isis_circuit_level)} circuit-type {$itf.isis_circuit_level}
  {/if}
   {if isset($itf.isis_auth_key)}  hello-padding disable
-   hello-password keychain  {$itf.isis_auth_key}
+   hello-password keychain {$itf.isis_auth_key}
   {/if}
   {if isset($itf.isis_network)}  {$itf.isis_network}
   {/if}
-  {if isset($itf.isis_csnp_interval) and isset($itf.isis_csnp_level)}  csnp-interval  {$itf.isis_csnp_interval} {$itf.isis_csnp_level}}  
+  {if isset($itf.isis_csnp_interval) and isset($itf.isis_csnp_level)} csnp-interval {$itf.isis_csnp_interval} {$itf.isis_csnp_level}
   {/if}
   {foreach $itf.metric as $metric} 
     {if isset($metric.isis_metric_level) and isset($metric.isis_metric)}   address-family ipv4 unicast


### PR DESCRIPTION
Before the fix:

 interface GigabitEthernet0/2/0/6
  hello-padding disable
  hello-password keychain  ISIS-PWD
  point-to-point
  csnp-interval  10 level-2}
  root
!

After the fix:

 interface GigabitEthernet0/2/0/6
  hello-padding disable
  hello-password keychain ISIS-PWD
  point-to-point
  csnp-interval 10 level-2
  root
!
