### PR TITLE
Added 14 bytes to the MTU on IOS-XR

### DIFF
--- a/CISCO/IOS_XR/.meta_interface.xml
+++ b/CISCO/IOS_XR/.meta_interface.xml
@@ -7,7 +7,7 @@
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1662729073056</value>
+            <value>1662991946885</value>
         </entry>
         <entry>
             <key>REPOSITORY</key>
@@ -15,7 +15,7 @@
         </entry>
         <entry>
             <key>DATE_CREATION</key>
-            <value>1662729073037</value>
+            <value>1662991946880</value>
         </entry>
         <entry>
             <key>MODEL</key>

--- a/CISCO/IOS_XR/interface.xml
+++ b/CISCO/IOS_XR/interface.xml
@@ -293,7 +293,7 @@ interface {$params.object_id}
  ipv6 {$params.ipv6_enable}
 {/if}
 {if isset($params.mtu_int)}
- mtu {$params.mtu_int}
+ mtu {$params.mtu_int+14}
 {/if}
 {if isset($params.ip_urpf)}
  ipv4 verify {$params.ip_urpf}
@@ -330,11 +330,8 @@ interface {$params.object_id}
  carrier-delay {if isset($params.carrier_delay_up)} up {$params.carrier_delay_up}000 {/if} {if isset($params.carrier_delay_up)} down {$params.carrier_delay_down}
 {/if}
 {/if}
-{if isset($params.route_cache) and $params.route_cache}
- ip route-cache {$params.route_cache}
-{/if}
 {if isset($params.duplex_mode) and $params.duplex_mode}
- duplex  {$params.duplex_mode}
+ duplex {$params.duplex_mode}
 {/if}
 root
 ! 


### PR DESCRIPTION
Before the fix:

interface GigabitEthernet0/2/0/6
 description meme
 ipv4 address 177.61.179.65 255.255.255.254
 ipv6 address 2001:12E0:B100:2E:177:61:179:65/127
 ipv6 enable
 mtu 8018
 mpls mtu 7984
 carrier-delay  up 2000  down 0
root

Same value 8018 of IOS

After the fix:

interface GigabitEthernet0/2/0/6
 description meme
 ipv4 address 177.61.179.65 255.255.255.254
 ipv6 address 2001:12E0:B100:2E:177:61:179:65/127
 ipv6 enable
 mtu 8032
 mpls mtu 7984
 carrier-delay  up 2000  down 0
root